### PR TITLE
F1819 multi access myql

### DIFF
--- a/.nullstone/module.yml
+++ b/.nullstone/module.yml
@@ -1,7 +1,7 @@
-org_name: nullstone
-name: aws-mysql-access
-friendly_name: MySQL Access
-description: Grants an application access to a newly-created mysql database managed by AWS
+org_name: Evolve
+name: aws-mysql-multiaccess
+friendly_name: MySQL Multi-Access
+description: Grants an application access to a primary mysql database as well as additional databases
 category: capability
 subcategory: datastores
 provider_types:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# aws-mysql-access
+# aws-mysql-multiaccess
 
 Nullstone capability to grant access for a mysql database to an app.
+If `additional_database_names` are specified, a user and owner permissions will be created for each database.
 
 ### Secrets
 

--- a/create.tf
+++ b/create.tf
@@ -39,6 +39,19 @@ data "aws_lambda_invocation" "create-db-access" {
   depends_on = [data.aws_lambda_invocation.create-user]
 }
 
+data "aws_lambda_invocation" "create-additional-databases" {
+  for_each = var.additional_database_names
+
+  function_name = local.db_admin_func_name
+
+  input = jsonencode({
+    type = "create-database"
+    metadata = {
+      databaseName = each.key
+    }
+  })
+}
+
 data "aws_lambda_invocation" "create-additional-access" {
   for_each = var.additional_database_names
 
@@ -51,4 +64,6 @@ data "aws_lambda_invocation" "create-additional-access" {
       username     = local.username
     }
   })
+
+  depends_on = [data.aws_lambda_invocation.create-additional-databases, data.aws_lambda_invocation.create-user]
 }

--- a/create.tf
+++ b/create.tf
@@ -38,3 +38,17 @@ data "aws_lambda_invocation" "create-db-access" {
 
   depends_on = [data.aws_lambda_invocation.create-user]
 }
+
+data "aws_lambda_invocation" "create-additional-access" {
+  for_each = var.additional_database_names
+
+  function_name = local.db_admin_func_name
+
+  input = jsonencode({
+    type = "create-db-access"
+    metadata = {
+      databaseName = each.key
+      username     = local.username
+    }
+  })
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,8 +10,21 @@ EOF
 
 variable "database_name" {
   type        = string
-  description = "Name of database to create in Mysql cluster"
+  description = <<EOF
+Name of database to create in the mysql cluster. If left blank, the name of the app will be used.
+If the database already exists, it will be reused.
+A new user will be created and granted owner permissions to the database schema.
+EOF
   default     = ""
+}
+
+variable "additional_database_names" {
+  type        = list(string)
+  description = <<EOF
+Additional databases to create in the mysql cluster. If any already exist, they will be reused.
+For each database, a new user will be created and granted owner permissions to the database schema.
+EOF
+  default     = []
 }
 
 locals {


### PR DESCRIPTION
This repo is a clone from nullstone/aws-mysql-access.

Then, I have added a new variable called `additional_database_names`.

For each item in this list of strings, we will upsert a database in the cluster. Then, we will grant access to those dbs from one single user.

The `database_name` parameter will still be the primary and the outputs emitted for env variables will be for this primary connection.

If the user wanted to connect to the other databases they could, they would just have to construct the db connection string themselves.